### PR TITLE
Remove position: sticky on .group > .header.

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -466,7 +466,6 @@ div.menu.visible {
   width: 100%;
   height: 24px;
   box-sizing: border-box;
-  position: sticky;
   z-index: 1;
   background: var(--surface-color);
   top: calc(50px);

--- a/sidebar.css
+++ b/sidebar.css
@@ -113,7 +113,6 @@ div.menu .action {
   width:auto;
   text-align:left;
   cursor:default;
-  white-space: nowrap;
 }
 
 div.menu .action span {
@@ -467,7 +466,6 @@ div.menu.visible {
   width: 100%;
   height: 24px;
   box-sizing: border-box;
-  position: sticky;
   z-index: 1;
   background: var(--surface-color);
   top: calc(50px);

--- a/sidebar.css
+++ b/sidebar.css
@@ -113,6 +113,7 @@ div.menu .action {
   width:auto;
   text-align:left;
   cursor:default;
+  white-space: nowrap;
 }
 
 div.menu .action span {
@@ -466,6 +467,7 @@ div.menu.visible {
   width: 100%;
   height: 24px;
   box-sizing: border-box;
+  position: sticky;
   z-index: 1;
   background: var(--surface-color);
   top: calc(50px);


### PR DESCRIPTION
This was causing headers to sometimes be placed in the vertical center of the group. 

<img width="316" alt="Screen Shot 2021-05-15 at 10 15 43" src="https://user-images.githubusercontent.com/72062/118343931-b0a7a300-b566-11eb-8950-030d5fc149d8.png">
